### PR TITLE
Updated setup guides to match dotnet 6.0

### DIFF
--- a/docker-files/web-api/Dockerfile
+++ b/docker-files/web-api/Dockerfile
@@ -8,7 +8,7 @@ USER developer
 WORKDIR /home/developer
 
 # Install the necessary SDK's and so on needed for the application
-FROM mcr.microsoft.com/dotnet//sdk:6.0 
+FROM mcr.microsoft.com/dotnet/sdk:6.0 
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 # Clone the web-api repository from github

--- a/docker-files/web-api/Dockerfile
+++ b/docker-files/web-api/Dockerfile
@@ -8,7 +8,7 @@ USER developer
 WORKDIR /home/developer
 
 # Install the necessary SDK's and so on needed for the application
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet//sdk:6.0 
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 # Clone the web-api repository from github

--- a/wiki/setup-guide/linux_setup.md
+++ b/wiki/setup-guide/linux_setup.md
@@ -26,14 +26,14 @@ After installing the IDE, please make sure to add extensions for Flutter in the 
 3. Flutter Framework\
     Install Flutter **2.0.5** using the steps described here: https://flutter.dev/docs/get-started/install, where the **2.0.5** version of Flutter can be found here https://flutter.dev/docs/development/tools/sdk/releases
 
-4. Install .Net Core \
-    Install dotnet **3.1** from this link: https://dotnet.microsoft.com/download/dotnet/3.1, or you can install it by using these commands: \
+4. Install .Net \
+    Install dotnet **6.0** from this link: https://dotnet.microsoft.com/en-us/download/dotnet/6.0, or you can install it by using these commands: \
     ```
     sudo wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
     sudo dpkg -i packages-microsoft-prod.deb 
     sudo apt update 
     sudo apt install apt-transport-https 
-    sudo apt install dotnet-sdk-3.1 
+    sudo apt install dotnet-sdk-6.0 
     ```
 
 5. Install additional libraries \

--- a/wiki/setup-guide/mac_setup.md
+++ b/wiki/setup-guide/mac_setup.md
@@ -34,8 +34,8 @@ After installing the IDE, please make sure to add extensions for Flutter in the 
 4. Cocoapods \
     Install cocoapods using this command: `sudo gem install cocoapods`
 
-4. Install .Net Core \
-    Install dotnet **3.1** from this link: https://dotnet.microsoft.com/download/dotnet/3.1, if not done automatically then add the .dotnet/tools to PATH.
+4. Install .Net \
+    Install dotnet **6.0** from this link: https://dotnet.microsoft.com/en-us/download/dotnet/6.0, if not done automatically then add the .dotnet/tools to your PATH.
 
 5. Install additional libraries \
     Use the following commands to install needed libraries for dotnet: 

--- a/wiki/setup-guide/windows_setup.md
+++ b/wiki/setup-guide/windows_setup.md
@@ -27,8 +27,8 @@ After installing the IDE, please make sure to add extensions for Flutter in the 
 3. Flutter Framework\
     Install Flutter **2.0.5** using the steps described here: https://flutter.dev/docs/get-started/install, where the **2.0.5** version of Flutter can be found here https://flutter.dev/docs/development/tools/sdk/releases
 
-4. Install .Net Core \
-    Install dotnet **3.1** from this link: https://dotnet.microsoft.com/download/dotnet/3.1
+4. Install .Net \
+    Install dotnet **6.0** from this link: https://dotnet.microsoft.com/download/dotnet/6.0
 
 5. Install MySQL \
     Install MySQL Server **8.0** from this link: https://dev.mysql.com/downloads/mysql/ \


### PR DESCRIPTION
# Description

Changed download links and instructions for dotnet 6.0. This is related to the pull request https://github.com/aau-giraf/web-api/pull/262

Fixes https://github.com/aau-giraf/web-api/issues/253

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

By pressing the links :)

**Development Configuration**
* SDK: .NET 6.0 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device. 