### PR TITLE
docs: weekplanner frontend is Flutter, not Expo/React Native

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Each repository uses slightly different tech stacks
 
 - [giraf-core](https://github.com/aau-giraf/giraf-core/blob/main/CONTRIBUTING.md) — Python/Django
 - [giraf-ai](https://github.com/aau-giraf/giraf-ai/blob/main/CONTRIBUTING.md) — Python
-- [weekplanner](https://github.com/aau-giraf/weekplanner/blob/main/CONTRIBUTING.md) — .NET + Expo/React Native
+- [weekplanner](https://github.com/aau-giraf/weekplanner/blob/main/CONTRIBUTING.md) — .NET + Flutter
 - [visual-tangible-artefacts](https://github.com/aau-giraf/visual-tangible-artefacts/blob/main/CONTRIBUTING.md) — .NET + Flutter
 - [foodplanner](https://github.com/aau-giraf/foodplanner/blob/main/CONTRIBUTING.md) — Flutter
 - [wiki](https://github.com/aau-giraf/wiki/blob/main/CONTRIBUTING.md) — MkDocs documentation


### PR DESCRIPTION
The weekplanner frontend is a Flutter app (weekplanner/frontend/pubspec.yaml, Flutter SDK >=3.44, flutter_bloc + go_router), not Expo/React Native. Corrects the per-repo setup list in CONTRIBUTING.md.